### PR TITLE
Ideas for performance improvements

### DIFF
--- a/app/src/main/java/eu/faircode/email/AdapterMessage.java
+++ b/app/src/main/java/eu/faircode/email/AdapterMessage.java
@@ -987,12 +987,7 @@ public class AdapterMessage extends RecyclerView.Adapter<AdapterMessage.ViewHold
             tvBcc.setVisibility(show_addresses && !TextUtils.isEmpty(bcc) ? View.VISIBLE : View.GONE);
             tvBcc.setText(bcc);
 
-            InternetAddress via = null;
-            if (message.identityEmail != null)
-                try {
-                    via = new InternetAddress(message.identityEmail, message.identityName);
-                } catch (UnsupportedEncodingException ignored) {
-                }
+            Address via = message.getVia();
 
             tvIdentityTitle.setVisibility(show_addresses && via != null ? View.VISIBLE : View.GONE);
             tvIdentity.setVisibility(show_addresses && via != null ? View.VISIBLE : View.GONE);

--- a/app/src/main/java/eu/faircode/email/Core.java
+++ b/app/src/main/java/eu/faircode/email/Core.java
@@ -1844,7 +1844,7 @@ class Core {
             return;
 
         DB db = DB.getInstance(context);
-        EntityMessage message = db.message().getMessage(id);
+        DownloadMessage message = db.message().getDownloadMessageById(id);
         if (message == null)
             return;
 

--- a/app/src/main/java/eu/faircode/email/Core.java
+++ b/app/src/main/java/eu/faircode/email/Core.java
@@ -1236,7 +1236,7 @@ class Core {
                 List<Message> full = new ArrayList<>();
                 for (Message imessage : isub) {
                     long uid = ifolder.getUID(imessage); // already fetched
-                    EntityMessage message = db.message().getMessageByUid(folder.id, uid);
+                    Long message = db.message().getMessageByUidExists(folder.id, uid);
                     if (message == null)
                         full.add(imessage);
                 }

--- a/app/src/main/java/eu/faircode/email/DaoMessage.java
+++ b/app/src/main/java/eu/faircode/email/DaoMessage.java
@@ -183,6 +183,11 @@ public interface DaoMessage {
             " WHERE id = :id")
     EntityMessage getMessage(long id);
 
+    @Query("SELECT id,size,content,warning" +
+            " FROM message" +
+            " WHERE id = :id")
+    DownloadMessage getDownloadMessageById(long id);
+
     @Query("SELECT content" +
             " FROM message" +
             " WHERE id = :id")

--- a/app/src/main/java/eu/faircode/email/DaoMessage.java
+++ b/app/src/main/java/eu/faircode/email/DaoMessage.java
@@ -484,6 +484,11 @@ public interface DaoMessage {
     int deleteMessage(long folder, long uid);
 
     @Query("DELETE FROM message" +
+           " WHERE folder = :folder" +
+           " AND uid IN(:uids)")
+    int deleteMessages(long folder, long[] uids);
+
+    @Query("DELETE FROM message" +
             " WHERE folder = :folder" +
             " AND NOT uid IS NULL")
     int deleteLocalMessages(long folder);

--- a/app/src/main/java/eu/faircode/email/DaoMessage.java
+++ b/app/src/main/java/eu/faircode/email/DaoMessage.java
@@ -183,6 +183,22 @@ public interface DaoMessage {
             " WHERE id = :id")
     EntityMessage getMessage(long id);
 
+    @Query("SELECT content" +
+            " FROM message" +
+            " WHERE id = :id")
+    Boolean getMessageByIdHasContent(long id);
+
+    @Query("SELECT raw" +
+            " FROM message" +
+            " WHERE id = :id")
+    Boolean getMessageByIdHasRaw(long id);
+
+    @Query("SELECT uid" +
+            " FROM message" +
+            " WHERE folder = :folder" +
+            " AND uid = :uid")
+    Long getMessageByUidExists(long folder, long uid);
+
     @Query("SELECT *" +
             " FROM message" +
             " WHERE folder = :folder" +

--- a/app/src/main/java/eu/faircode/email/DownloadMessage.java
+++ b/app/src/main/java/eu/faircode/email/DownloadMessage.java
@@ -1,0 +1,24 @@
+package eu.faircode.email;
+
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+import androidx.room.PrimaryKey;
+
+import java.io.File;
+
+class DownloadMessage {
+    @PrimaryKey(autoGenerate = true)
+    public Long id;
+    public Long size;
+    @NonNull
+    public Boolean content = false;
+    public String warning; // persistent
+
+    File getFile(Context context) {
+        File dir = new File(context.getFilesDir(), "messages");
+        if (!dir.exists())
+            dir.mkdir();
+        return new File(dir, id.toString());
+    }
+}

--- a/app/src/main/java/eu/faircode/email/EntityMessage.java
+++ b/app/src/main/java/eu/faircode/email/EntityMessage.java
@@ -75,11 +75,9 @@ import static androidx.room.ForeignKey.SET_NULL;
                 @Index(value = {"ui_snoozed"})
         }
 )
-public class EntityMessage implements Serializable {
+public class EntityMessage extends DownloadMessage implements Serializable {
     static final String TABLE_NAME = "message";
 
-    @PrimaryKey(autoGenerate = true)
-    public Long id;
     @NonNull
     public Long account; // performance
     @NonNull
@@ -111,11 +109,8 @@ public class EntityMessage implements Serializable {
     public String headers;
     public Boolean raw;
     public String subject;
-    public Long size;
     @NonNull
     public Integer attachments = 0; // performance
-    @NonNull
-    public Boolean content = false;
     public Boolean plain_only = null;
     public Boolean encrypt = null;
     public String preview;
@@ -152,7 +147,6 @@ public class EntityMessage implements Serializable {
     public Integer color;
     public Integer revision; // compose
     public Integer revisions; // compose
-    public String warning; // persistent
     public String error; // volatile
     public Long last_attempt; // send
 
@@ -192,13 +186,6 @@ public class EntityMessage implements Serializable {
         }
 
         return addresses.toArray(new Address[0]);
-    }
-
-    File getFile(Context context) {
-        File dir = new File(context.getFilesDir(), "messages");
-        if (!dir.exists())
-            dir.mkdir();
-        return new File(dir, id.toString());
     }
 
     File getFile(Context context, int revision) {

--- a/app/src/main/java/eu/faircode/email/EntityRule.java
+++ b/app/src/main/java/eu/faircode/email/EntityRule.java
@@ -46,6 +46,7 @@ import javax.mail.Header;
 import javax.mail.Message;
 import javax.mail.MessagingException;
 import javax.mail.internet.InternetAddress;
+import javax.mail.internet.InternetAddressImpl;
 
 import static androidx.room.ForeignKey.CASCADE;
 
@@ -323,7 +324,7 @@ public class EntityRule {
         reply.inreplyto = message.msgid;
         reply.thread = message.thread;
         reply.to = (message.reply == null || message.reply.length == 0 ? message.from : message.reply);
-        reply.from = new InternetAddress[]{new InternetAddress(identity.email, identity.name)};
+        reply.from = new InternetAddressImpl[]{new InternetAddressImpl(identity.email, identity.name)};
         if (cc)
             reply.cc = message.cc;
         reply.subject = context.getString(R.string.title_subject_reply, message.subject == null ? "" : message.subject);

--- a/app/src/main/java/eu/faircode/email/FragmentCompose.java
+++ b/app/src/main/java/eu/faircode/email/FragmentCompose.java
@@ -143,6 +143,7 @@ import javax.mail.Part;
 import javax.mail.Session;
 import javax.mail.internet.AddressException;
 import javax.mail.internet.InternetAddress;
+import javax.mail.internet.InternetAddressImpl;
 import javax.mail.internet.MimeMessage;
 
 import static android.app.Activity.RESULT_OK;
@@ -1240,7 +1241,7 @@ public class FragmentCompose extends FragmentBase {
                             if (address != null)
                                 list.addAll(Arrays.asList(address));
 
-                            list.add(new InternetAddress(email, name));
+                            list.add(new InternetAddressImpl(email, name));
 
                             if (requestCode == REQUEST_CONTACT_TO)
                                 draft.to = list.toArray(new Address[0]);
@@ -1622,7 +1623,7 @@ public class FragmentCompose extends FragmentBase {
                             if (contact != null && contact.moveToNext()) {
                                 String name = contact.getString(0);
                                 String email = contact.getString(1);
-                                selected.add(new InternetAddress(email, name));
+                                selected.add(new InternetAddressImpl(email, name));
                             }
                         }
                     }
@@ -2078,7 +2079,7 @@ public class FragmentCompose extends FragmentBase {
                             String via = null;
                             if (ref.identity != null) {
                                 EntityIdentity identity = db.identity().getIdentity(ref.identity);
-                                draft.from = new Address[]{new InternetAddress(identity.email, identity.name)};
+                                draft.from = new Address[]{new InternetAddressImpl(identity.email, identity.name)};
                                 via = MessageHelper.canonicalAddress(identity.email);
                             }
 
@@ -2162,7 +2163,7 @@ public class FragmentCompose extends FragmentBase {
                             String email = MessageHelper.canonicalAddress(identity.email);
                             if (email.equals(from)) {
                                 draft.identity = identity.id;
-                                draft.from = new InternetAddress[]{new InternetAddress(identity.email, identity.name)};
+                                draft.from = new InternetAddressImpl[]{new InternetAddressImpl(identity.email, identity.name)};
                                 break;
                             }
                             if (identity.account.equals(draft.account)) {
@@ -2183,10 +2184,10 @@ public class FragmentCompose extends FragmentBase {
                     if (draft.identity == null) {
                         if (primary != null) {
                             draft.identity = primary.id;
-                            draft.from = new InternetAddress[]{new InternetAddress(primary.email, primary.name)};
+                            draft.from = new InternetAddressImpl[]{new InternetAddressImpl(primary.email, primary.name)};
                         } else if (first != null && icount == 1) {
                             draft.identity = first.id;
-                            draft.from = new InternetAddress[]{new InternetAddress(first.email, first.name)};
+                            draft.from = new InternetAddressImpl[]{new InternetAddressImpl(first.email, first.name)};
                         }
                     }
 
@@ -2557,11 +2558,11 @@ public class FragmentCompose extends FragmentBase {
                     List<EntityAttachment> attachments = db.attachment().getAttachments(draft.id);
 
                     // Get data
-                    InternetAddress afrom[] = (identity == null ? null : new InternetAddress[]{new InternetAddress(identity.email, identity.name)});
+                    InternetAddressImpl afrom[] = (identity == null ? null : new InternetAddressImpl[]{new InternetAddressImpl(identity.email, identity.name)});
 
-                    InternetAddress ato[] = null;
-                    InternetAddress acc[] = null;
-                    InternetAddress abcc[] = null;
+                    InternetAddress[] ato = null;
+                    InternetAddress[] acc = null;
+                    InternetAddress[] abcc = null;
 
                     boolean lookup_mx = prefs.getBoolean("lookup_mx", false);
 

--- a/app/src/main/java/eu/faircode/email/Helper.java
+++ b/app/src/main/java/eu/faircode/email/Helper.java
@@ -72,6 +72,8 @@ import androidx.preference.PreferenceManager;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 import com.sun.mail.iap.ConnectionException;
 import com.sun.mail.util.FolderClosedIOException;
+import org.json.JSONException;
+import org.json.JSONObject;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -876,4 +878,18 @@ public class Helper {
         bundle.writeToParcel(p, 0);
         return p.dataSize();
     }
+
+    public static int computeAddressHashcode(JSONObject jsonObject) {
+        int ia = 0;
+        int ip = 0;
+        String address = null;
+        try {
+            ia = jsonObject.getString("address").hashCode();
+            if (jsonObject.has("personal")) {
+                ip = jsonObject.getString("personal").hashCode();
+            }
+        } catch (JSONException ignored) { }
+        return ia*2 + ip*8;
+    }
+
 }

--- a/app/src/main/java/eu/faircode/email/Log.java
+++ b/app/src/main/java/eu/faircode/email/Log.java
@@ -80,7 +80,7 @@ import java.util.concurrent.TimeoutException;
 import javax.mail.Address;
 import javax.mail.MessagingException;
 import javax.mail.Part;
-import javax.mail.internet.InternetAddress;
+import javax.mail.internet.InternetAddressImpl;
 
 public class Log {
     private static final String TAG = "fairemail";
@@ -750,7 +750,7 @@ public class Log {
         return (int) (getFreeMem() / 1024L / 1024L);
     }
 
-    static InternetAddress myAddress() throws UnsupportedEncodingException {
-        return new InternetAddress("marcel+fairemail@faircode.eu", "FairCode");
+    static InternetAddressImpl myAddress() throws UnsupportedEncodingException {
+        return new InternetAddressImpl("marcel+fairemail@faircode.eu", "FairCode");
     }
 }

--- a/app/src/main/java/eu/faircode/email/MessageHelper.java
+++ b/app/src/main/java/eu/faircode/email/MessageHelper.java
@@ -67,6 +67,7 @@ import javax.mail.Session;
 import javax.mail.internet.AddressException;
 import javax.mail.internet.ContentType;
 import javax.mail.internet.InternetAddress;
+import javax.mail.internet.InternetAddressImpl;
 import javax.mail.internet.MailDateFormat;
 import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMessage;
@@ -553,7 +554,7 @@ public class MessageHelper {
                     try {
                         MailTo mailto = MailTo.parse(to.substring(lt + 1, gt));
                         if (mailto.getTo() != null)
-                            return new Address[]{new InternetAddress(mailto.getTo().split(",")[0])};
+                            return new Address[]{new InternetAddressImpl(mailto.getTo().split(",")[0])};
                     } catch (android.net.ParseException ex) {
                         Log.i(ex);
                     }
@@ -1138,9 +1139,14 @@ public class MessageHelper {
         if (a1.length != a2.length)
             return false;
 
-        for (int i = 0; i < a1.length; i++)
-            if (!a1[i].toString().equals(a2[i].toString()))
+        Address address1;
+        Address address2;
+        for (int i = 0; i < a1.length; i++) {
+            address1 = a1[i];
+            address2 = a2[i];
+            if (!address1.equals(address2))
                 return false;
+        }
 
         return true;
     }

--- a/app/src/main/java/eu/faircode/email/ServiceSend.java
+++ b/app/src/main/java/eu/faircode/email/ServiceSend.java
@@ -55,7 +55,7 @@ import javax.mail.MessageRemovedException;
 import javax.mail.MessagingException;
 import javax.mail.SendFailedException;
 import javax.mail.Session;
-import javax.mail.internet.InternetAddress;
+import javax.mail.internet.InternetAddressImpl;
 import javax.mail.internet.MimeMessage;
 
 import static android.os.Process.THREAD_PRIORITY_BACKGROUND;
@@ -326,7 +326,7 @@ public class ServiceSend extends ServiceBase {
 
         // Add reply to
         if (ident.replyto != null)
-            imessage.setReplyTo(new Address[]{new InternetAddress(ident.replyto)});
+            imessage.setReplyTo(new Address[]{new InternetAddressImpl(ident.replyto)});
 
         // Add bcc
         if (ident.bcc != null) {
@@ -334,7 +334,7 @@ public class ServiceSend extends ServiceBase {
             Address[] existing = imessage.getRecipients(Message.RecipientType.BCC);
             if (existing != null)
                 bcc.addAll(Arrays.asList(existing));
-            bcc.add(new InternetAddress(ident.bcc));
+            bcc.add(new InternetAddressImpl(ident.bcc));
             imessage.setRecipients(Message.RecipientType.BCC, bcc.toArray(new Address[0]));
         }
 

--- a/app/src/main/java/eu/faircode/email/WorkerCleanup.java
+++ b/app/src/main/java/eu/faircode/email/WorkerCleanup.java
@@ -70,14 +70,14 @@ public class WorkerCleanup extends Worker {
                 // Check message files
                 Log.i("Checking message files");
                 List<Long> mids = db.message().getMessageWithContent();
+                File dir = new File(context.getFilesDir(), "messages");
+                if (!dir.exists())
+                    dir.mkdir();
                 for (Long mid : mids) {
-                    EntityMessage message = db.message().getMessage(mid);
-                    if (message != null) {
-                        File file = message.getFile(context);
-                        if (!file.exists()) {
-                            Log.w("Message file missing id=" + mid);
-                            db.message().setMessageContent(mid, false);
-                        }
+                    File file = new File(dir, mid.toString());
+                    if (!file.exists()) {
+                        Log.w("Message file missing id=" + mid);
+                        db.message().setMessageContent(mid, false);
                     }
                 }
 
@@ -119,8 +119,8 @@ public class WorkerCleanup extends Worker {
             for (File file : files)
                 if (manual || file.lastModified() + KEEP_FILES_DURATION < now) {
                     long id = Long.parseLong(file.getName().split("\\.")[0]);
-                    EntityMessage message = db.message().getMessage(id);
-                    if (message == null || !message.content) {
+                    Boolean content = db.message().getMessageByIdHasContent(id);
+                    if (content == null || !content) {
                         Log.i("Deleting " + file);
                         if (!file.delete())
                             Log.w("Error deleting " + file);
@@ -134,8 +134,8 @@ public class WorkerCleanup extends Worker {
                 for (File file : raws)
                     if (manual || file.lastModified() + KEEP_FILES_DURATION < now) {
                         long id = Long.parseLong(file.getName().split("\\.")[0]);
-                        EntityMessage message = db.message().getMessage(id);
-                        if (message == null || message.raw == null || !message.raw) {
+                        Boolean raw = db.message().getMessageByIdHasRaw(id);
+                        if (raw == null || !raw) {
                             Log.i("Deleting " + file);
                             if (!file.delete())
                                 Log.w("Error deleting " + file);

--- a/app/src/main/java/javax/mail/internet/InternetAddressImpl.java
+++ b/app/src/main/java/javax/mail/internet/InternetAddressImpl.java
@@ -1,0 +1,51 @@
+package javax.mail.internet;
+
+import javax.mail.Address;
+import java.io.UnsupportedEncodingException;
+import java.util.Objects;
+
+public class InternetAddressImpl extends InternetAddress {
+    public InternetAddressImpl() {
+        super();
+    }
+
+    public InternetAddressImpl(String address) throws AddressException {
+        super(address);
+    }
+
+    public InternetAddressImpl(String address, boolean strict) throws AddressException {
+        super(address, strict);
+    }
+
+    public InternetAddressImpl(String address, String personal) throws UnsupportedEncodingException {
+        super(address, personal);
+    }
+
+    public InternetAddressImpl(String address, String personal, String charset) throws UnsupportedEncodingException {
+        super(address, personal, charset);
+    }
+
+    public InternetAddressImpl(InternetAddress address) throws UnsupportedEncodingException {
+        setAddress(address.address);
+        setPersonal(address.personal);
+    }
+
+    @Override
+    public boolean equals(Object a) {
+        if (!super.equals(a)) return false;
+
+        InternetAddressImpl address1 = this;
+        InternetAddress address2 = (InternetAddress) a; // super.equals checked for a instanceof InternetAddress
+        // super.equals already checked this.address for equality
+        return Objects.equals(address1.getPersonal(), address2.getPersonal());
+    }
+
+    @Override
+    public int hashCode() {
+        String personal = this.getPersonal();
+        int personalHash = 0;
+        if (personal != null)
+            personalHash = personal.hashCode();
+        return super.hashCode() + personalHash*2;
+    }
+}

--- a/app/src/main/java/org/json/JSONAddress.java
+++ b/app/src/main/java/org/json/JSONAddress.java
@@ -1,0 +1,22 @@
+package org.json;
+
+import eu.faircode.email.Helper;
+
+public class JSONAddress extends JSONObject {
+
+    public final JSONObject jsonObject;
+
+    public JSONAddress(JSONObject jsonObject) {
+        this.jsonObject = jsonObject;
+    }
+
+    @Override
+    public int hashCode() {
+        return Helper.computeAddressHashcode(jsonObject);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj != null && this.hashCode() == obj.hashCode();
+    }
+}


### PR DESCRIPTION
Hi @M66B, I don't expect this to be merged but maybe you find parts of these commits useful :)

While profiling your app I found out most of the time during sync and viewing messages is spent in `decodeAddresses` especially in parsing/instantiating an `InternetAddress`.

I wrote up a kinda hacky cache implementation but I'd probably be better to reduce decoding addresses where it is not needed, as in b56d0dd546cc360dd4c173c5b9c63adc0a328575 or 90ec110f417cd2587508b0ae7b16b0136d98d2e9.