### PR TITLE
Add sponsor button linking to Google Play

### DIFF
--- a/FUNDING.yml
+++ b/FUNDING.yml
@@ -1,0 +1,1 @@
+custom: https://play.google.com/store/apps/details?id=eu.faircode.email


### PR DESCRIPTION
After you enable this on your repository, it'll show a sponsor button left of watch which links to Google Play. More info on https://help.github.com/en/github/building-a-strong-community/displaying-a-sponsor-button-in-your-repository.

Also, may I suggest signing up for GitHub Sponsors? Right now they have no fees at all and match any sponsorship. You could set a 6 Euro tier for a pro key maybe and tell people to email you if they use it so you avoid all Google's fees? Up to you, of course :)