### PR TITLE
Hide accountname prefix if same as email

### DIFF
--- a/app/src/main/java/eu/faircode/email/AdapterIdentitySelect.java
+++ b/app/src/main/java/eu/faircode/email/AdapterIdentitySelect.java
@@ -44,7 +44,8 @@ public class AdapterIdentitySelect extends ArrayAdapter<TupleIdentityEx> {
         TextView text2 = view.findViewById(android.R.id.text2);
 
         vwColor.setBackgroundColor(identity.color == null ? Color.TRANSPARENT : identity.color);
-        text1.setText(identity.accountName + "/" + identity.getDisplayName() + (identity.primary ? " ★" : ""));
+        String identityPrefix = identity.accountName != identity.email ? identity.accountName + "/" : "";
+        text1.setText(identityPrefix + identity.getDisplayName() + (identity.primary ? " ★" : ""));
         text2.setText(identity.email);
 
         return view;


### PR DESCRIPTION
# Important

* Did you read the [contributing section](https://github.com/M66B/FairEmail#contributing)? Yes
* Do you agree to [the license and the copyright](https://github.com/M66B/FairEmail#license)? Yes

I know the contributing says to first contact you about my plans, but this patch is so small...

When I compose a new email, the identity field is rather long, turning multi-line:
![photo5922585126536065381](https://user-images.githubusercontent.com/1885159/68494020-f129b080-024d-11ea-85c9-a2e58b7963b5.jpg)

Because my account name and email address match in this case, it feels unnecessary to have it displayed twice. Having just my display name displayed on the first line would be sufficient and preferable I feel.

I must admit I have not tested this patch as I am not an Android developer and don't have an Android Studio install ready, but I see no reason to believe this patch would be problematic.