### PR TITLE
Fix Runbox IMAP host.

### DIFF
--- a/app/src/main/res/xml/providers.xml
+++ b/app/src/main/res/xml/providers.xml
@@ -353,7 +353,7 @@
         name="Runbox"
         link="https://help.runbox.com/email-program-settings/">
         <imap
-            host="imap.runbox.com"
+            host="mail.runbox.com"
             port="993"
             starttls="false" />
         <smtp


### PR DESCRIPTION
*First of all, thanks for the great app. K9 is really buggy for a MS account I use and so far I'm quite happy with FairEmail. I'll play with it some more before looking into Pro and leaving a review.*

I can't quite remember, but I believe the Runbox IMAP host listed in the app is an old one. I'm not sure if it still works. Regardless, their documentation lists mail.runbox.com, and I can confirm it works in the app. See their documentation [here](https://help.runbox.com/email-program-settings/) and [here](https://help.runbox.com/imap/).

I will point out that I didn't build or test as I don't have any Android tools set up. I assume that's not an issue for this kind of fix.
