### PR TITLE
Add Hetzner Online as mail provider

### DIFF
--- a/app/src/main/res/xml/providers.xml
+++ b/app/src/main/res/xml/providers.xml
@@ -474,4 +474,16 @@
             port="465"
             starttls="false" />
     </provider>
+    <provider
+        name="Hetzner Online"
+        link="https://wiki.hetzner.de/index.php/KonsoleH:Email-Konto_einrichten/en">
+        <imap
+            host="mail.your-server.de"
+            port="993"
+            starttls="false" />
+        <smtp
+            host="mail.your-server.de"
+            port="465"
+            starttls="false" />
+    </provider>
 </providers>


### PR DESCRIPTION
This adds mail.your-server.de (Hetzner Online) to the provider list

--
* Did you read the [contributing section](https://github.com/M66B/FairEmail#contributing)?
Yes
* Do you agree to [the license and the copyright](https://github.com/M66B/FairEmail#license)?
Yes
