### PR TITLE
Colon added

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -307,7 +307,7 @@
 
     <string name="title_advanced_landscape">Use two columns in landscape mode</string>
     <string name="title_advanced_landscape3">Allow fixed navigation menu in landscape mode</string>
-    <string name="title_advanced_startup">Show on start screen</string>
+    <string name="title_advanced_startup">Show on start screen:</string>
     <string name="title_advanced_cards">Use card style instead of tabular style</string>
     <string name="title_advanced_date_header">Group by date</string>
     <string name="title_advanced_threading">Conversation threading</string>


### PR DESCRIPTION
»Show on start screen:« 
I think it is better for the context to add a colon. Because there is a dialog after this. And the dialog is in the next line under it.

# Important

* Did you read the [contributing section](https://github.com/M66B/FairEmail#contributing)? Yes
* Do you agree to [the license and the copyright](https://github.com/M66B/FairEmail#license)? Yes
