### PR TITLE
Identity regex domain tolerance

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -1204,6 +1204,8 @@ It is possible to configure a [regex](https://en.wikipedia.org/wiki/Regular_expr
 to match the username of an email address (the part before the @ sign).
 
 Note that the domain name (the parts after the @ sign) always needs to be equal to the domain name of the identity.
+if you specify the domain part in your expression, the pattern has to match the domain part of the identity, otherwise,
+the matching will always fail (except for the address of the identity itself).
 
 If you like to match the special purpose email addresses abc@example.com and xyx@example.com
 and like to have a fallback email address main@example.com as well, you could do something like this:

--- a/app/src/main/java/eu/faircode/email/EntityIdentity.java
+++ b/app/src/main/java/eu/faircode/email/EntityIdentity.java
@@ -154,7 +154,14 @@ public class EntityIdentity {
             if (user.equalsIgnoreCase(cemail[0]))
                 return true;
         } else {
-            if (Pattern.matches(sender_extra_regex, cother[0]))
+            /* match by regex
+             * if the expression contains @, assume the pattern also contains the domain part.
+             * if no @ is contained, assume only the local part should be matched.
+             * Domain part must match identity domain part in any case, else
+             * this is never reached ( see cother[1] comparison above)
+             */
+            String matchInput = (sender_extra_regex.contains("@") ? matchInput = other : cother[0];
+            if (Pattern.matches(sender_extra_regex, matchInput))
                 return true;
         }
 

--- a/app/src/main/java/eu/faircode/email/FragmentCompose.java
+++ b/app/src/main/java/eu/faircode/email/FragmentCompose.java
@@ -3307,7 +3307,7 @@ public class FragmentCompose extends FragmentBase {
                                     data.draft.to = ref.to;
                                 } else {
                                     data.draft.from = ref.to;
-                                    data.draft.to = (ref.reply == null || ref.reply.length == 0 ? ref.from : ref.reply);
+                                    data.draft.to = (ref.reply == null || ref.reply.length == 0) ? ref.from : ref.reply;
                                 }
 
                                 if (data.draft.from != null && data.draft.from.length > 0) {


### PR DESCRIPTION
Assume you have an identity
Identity `me@example.com`
    Email-Address `me@example.com`
    Domain `dpsg-stamm-falke.de`
    Regex `(?i)(me|you)@example\.com`

The identity is only matchig me@example.com, but not you@example.com
You had to leave out the domain part in the pattern, only specifying
`(?i)(me|you)` to make it work.

*Effect of this commit:*
- This commit will allow users to use both variants.
- This commit will NOT allow users to match different domains
  in the identity (as before).

*Reason for the change:*
Better usability/fault tolerance. The user may have overread that the
pattern must only match the local part and enters the whole pattern,
thinking he has to do so in order to not match any other mail address
with the same local part.