### PR TITLE
add german provider all-inkl.com

### DIFF
--- a/app/src/main/res/xml/providers.xml
+++ b/app/src/main/res/xml/providers.xml
@@ -817,4 +817,20 @@
             port="465"
             starttls="false" />
     </provider>
+    <provider
+        name="all-inkl.com"
+        link="https://all-inkl.com/wichtig/anleitungen/programme/e-mail/aktualisierung-ssl-zertifikat-e-mail-einstellungen/einrichtung-von-e-mail-postfaechern_386.html">
+        <imap
+            host="KAS-LOGINNAME.kasserver.com"
+            port="143"
+            starttls="true" />
+        <smtp
+            host="KAS-LOGINNAME.kasserver.com"
+            port="587"
+            starttls="true" />
+        <documentation
+            url="http://kasserver.com">
+            <descr>Zugangsdaten: Im KAS (technische Verwaltung) unter E-Mail - E-Mail-Postfach hinter dem Postfach auf Bearbeiten klicken</descr>
+        </documentation>
+    </provider>
 </providers>


### PR DESCRIPTION
# Add german provider `all-inkl.com`

This will enable the provider all-inkl.com in the providers list.

* Provider does not use domain name (e.g. `yourdomain.com`) as hostname but technical domain name in the form `<loginname>.kasserver.com`.
* Provider also does not use emailaddress or local part but a username `m0373238` for authentication.
* Autoconfiguration using SRV dns records is currently not provided but works if the domain owner adds them manually to DNS.
  (checked by myself and wrote email to support if they want to enableset these records by default)
* Credentials are provided to the user in the domain administration page linked.