### PR TITLE
Replace usage of android.net.MailTo with androidx.core.net.MailTo

### DIFF
--- a/app/src/main/java/eu/faircode/email/ActivityCompose.java
+++ b/app/src/main/java/eu/faircode/email/ActivityCompose.java
@@ -20,7 +20,6 @@ package eu.faircode.email;
 */
 
 import android.content.Intent;
-import android.net.MailTo;
 import android.net.Uri;
 import android.os.Bundle;
 import android.text.Html;
@@ -28,6 +27,7 @@ import android.text.Spanned;
 import android.text.TextUtils;
 
 import androidx.core.app.TaskStackBuilder;
+import androidx.core.net.MailTo;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentTransaction;
 
@@ -89,12 +89,7 @@ public class ActivityCompose extends ActivityBase implements FragmentManager.OnB
             Uri uri = intent.getData();
             if (uri != null && "mailto".equals(uri.getScheme())) {
                 // https://www.ietf.org/rfc/rfc2368.txt
-                String url = uri.toString();
-                int query = url.indexOf('?', MailTo.MAILTO_SCHEME.length());
-                if (query > 0)
-                    url = url.substring(0, query) + url.substring(query).replace(":", "%3A");
-
-                MailTo mailto = MailTo.parse(url);
+                MailTo mailto = MailTo.parse(uri.toString());
 
                 String to = mailto.getTo();
                 if (to != null)

--- a/app/src/main/java/eu/faircode/email/IPInfo.java
+++ b/app/src/main/java/eu/faircode/email/IPInfo.java
@@ -20,10 +20,11 @@ package eu.faircode.email;
 */
 
 import android.content.Context;
-import android.net.MailTo;
 import android.net.ParseException;
 import android.net.Uri;
 import android.util.Pair;
+
+import androidx.core.net.MailTo;
 
 import java.io.IOException;
 import java.net.InetAddress;

--- a/app/src/main/java/eu/faircode/email/MessageHelper.java
+++ b/app/src/main/java/eu/faircode/email/MessageHelper.java
@@ -21,10 +21,10 @@ package eu.faircode.email;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-import android.net.MailTo;
 import android.net.Uri;
 import android.text.TextUtils;
 
+import androidx.core.net.MailTo;
 import androidx.documentfile.provider.DocumentFile;
 import androidx.preference.PreferenceManager;
 


### PR DESCRIPTION
Use the AndroidX version of `MailTo` instead of the broken platform version.

For more information see https://cketti.de/2020/06/22/android-net-mailto-is-broken/

* [x] I read the [contributing section](https://github.com/M66B/FairEmail#contributing)
* [x] I agree to [the license and the copyright](https://github.com/M66B/FairEmail#license)
