### PR TITLE
Check public key email using ignore case sensitivity

### DIFF
--- a/app/src/main/java/eu/faircode/email/FragmentCompose.java
+++ b/app/src/main/java/eu/faircode/email/FragmentCompose.java
@@ -2731,7 +2731,7 @@ public class FragmentCompose extends FragmentBase {
                     boolean known = false;
                     List<String> emails = EntityCertificate.getEmailAddresses(chain[0]);
                     for (String email : emails)
-                        if (email.equals(identity.email)) {
+                        if (email.equalsIgnoreCase(identity.email)) {
                             known = true;
                             break;
                         }


### PR DESCRIPTION
If a mail account is setup in FairEmail using Foo@Bar.com, a public key is now accepted issued for foo@bar.com