### PR TITLE
On Link tap compare title path with actual link instead of hostname

### DIFF
--- a/app/src/main/java/eu/faircode/email/AdapterMessage.java
+++ b/app/src/main/java/eu/faircode/email/AdapterMessage.java
@@ -6231,7 +6231,7 @@ public class AdapterMessage extends RecyclerView.Adapter<AdapterMessage.ViewHold
 
             grpDifferent.setVisibility(uri.getHost() == null ||
                     uriTitle == null || uriTitle.getHost() == null ||
-                    uriTitle.getHost().equalsIgnoreCase(uri.getHost())
+                    uriTitle.getPath().equalsIgnoreCase(uri.getPath())
                     ? View.GONE : View.VISIBLE);
 
             boolean disconnect_links = prefs.getBoolean("disconnect_links", true);


### PR DESCRIPTION
## Navigate to link
When tapping an email link it tries to find tracking links and it checks if the link is equal to the title (if it is a valid uri).
Right now it checks only for the host, not the entire path. This leads to situations where it fails to identify tracking uri and also it is hard for the user to navigate to the original link (title).
For example the title is:
http://somedomain.xyz/newsletter/unsubscribe.html
but the link is:
https://somedomain.xyz/sendy/l/Cp3P8iCv1PCMdB7nqmKZZA/D9xd0Lo5892VSAEV1VLW7W3w/WPwsL111NWGNiUw

Hostname remains the same but path changes. By checking the entire path the user can easily identify the difference and click the button to navigate to the title.

## Important
I confirm to

* read the [contributing section](https://github.com/M66B/FairEmail#contributing)
* agree to [the license and the copyright](https://github.com/M66B/FairEmail#license)