### PR TITLE
Fix attachment indicator for screen reader users

### DIFF
--- a/app/src/main/res/layout/include_message_compact.xml
+++ b/app/src/main/res/layout/include_message_compact.xml
@@ -240,7 +240,6 @@
         android:layout_width="21dp"
         android:layout_height="21dp"
         android:layout_marginStart="6dp"
-        android:contentDescription="@string/title_legend_attachment"
         app:layout_constraintBottom_toBottomOf="@+id/tvSubject"
         app:layout_constraintStart_toEndOf="@id/ivForwarded"
         app:layout_constraintTop_toTopOf="@+id/tvSubject"

--- a/app/src/main/res/layout/include_message_normal.xml
+++ b/app/src/main/res/layout/include_message_normal.xml
@@ -279,7 +279,6 @@
         android:layout_width="21dp"
         android:layout_height="21dp"
         android:layout_marginStart="6dp"
-        android:contentDescription="@string/title_legend_attachment"
         app:layout_constraintBottom_toBottomOf="@+id/tvFolder"
         app:layout_constraintStart_toEndOf="@id/ivForwarded"
         app:layout_constraintTop_toTopOf="@+id/tvFolder"


### PR DESCRIPTION
Some screen readers present attachment indicator twice, once as part of populated content description of a message item, second time as an image with content description. To improve the behaviour, remove the content description from the image so it won't be reported.

Signed-off-by: Peter Vágner <pvdeejay@gmail.com>

# Important

Please confirm that you:

* read the [contributing section](https://github.com/M66B/FairEmail#user-content-contributing)
* agree to [the license and the copyright](https://github.com/M66B/FairEmail#user-content-license)

Thanks for your intention to contribute to the project!
