### PR TITLE
Use ShareCompat.IntentBuilder to share an attachment

### DIFF
--- a/app/src/main/java/eu/faircode/email/AdapterAttachment.java
+++ b/app/src/main/java/eu/faircode/email/AdapterAttachment.java
@@ -41,6 +41,7 @@ import android.widget.Toast;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AlertDialog;
+import androidx.core.app.ShareCompat;
 import androidx.core.content.FileProvider;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.Lifecycle;
@@ -271,12 +272,10 @@ public class AdapterAttachment extends RecyclerView.Adapter<AdapterAttachment.Vi
                 Uri uri = FileProvider.getUriForFile(context, BuildConfig.APPLICATION_ID, file);
                 // TODO: consider using getUriForFile(..., displayName)
 
-                Intent send = new Intent();
-                send.setAction(Intent.ACTION_SEND);
-                send.putExtra(Intent.EXTRA_STREAM, uri);
-                send.setType(attachment.getMimeType());
-                send.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-                context.startActivity(Intent.createChooser(send, context.getString(R.string.title_select_app)));
+                new ShareCompat.IntentBuilder(context)
+                        .setType(attachment.getMimeType())
+                        .addStream(uri)
+                        .startChooser();
 
                 return true;
             } catch (Throwable ex) {

--- a/app/src/main/java/eu/faircode/email/AdapterMessage.java
+++ b/app/src/main/java/eu/faircode/email/AdapterMessage.java
@@ -116,6 +116,7 @@ import androidx.appcompat.widget.PopupMenu;
 import androidx.constraintlayout.helper.widget.Flow;
 import androidx.constraintlayout.widget.ConstraintLayout;
 import androidx.constraintlayout.widget.Group;
+import androidx.core.app.ShareCompat;
 import androidx.core.content.ContextCompat;
 import androidx.core.content.FileProvider;
 import androidx.core.content.pm.ShortcutInfoCompat;
@@ -3984,12 +3985,12 @@ public class AdapterMessage extends RecyclerView.Adapter<AdapterMessage.ViewHold
                     if (uris == null)
                         return;
 
-                    final Intent intent = new Intent(Intent.ACTION_SEND_MULTIPLE);
-                    intent.putParcelableArrayListExtra(Intent.EXTRA_STREAM, uris);
-                    intent.setType("image/*");
-                    intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
-                    intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
-                    context.startActivity(Intent.createChooser(intent, context.getString(R.string.app_name)));
+                    ShareCompat.IntentBuilder shareIntentBuilder = new ShareCompat.IntentBuilder(context);
+                    shareIntentBuilder.setType("image/*");
+                    for (Uri uri: uris) {
+                       shareIntentBuilder.addStream(uri);
+                    }
+                    shareIntentBuilder.startChooser();
                 }
 
                 @Override


### PR DESCRIPTION
This way the share sheet will show a preview when sharing images.

# Important

Please confirm that you:

* read the [contributing section](https://github.com/M66B/FairEmail#user-content-contributing)
* read the [get support section](https://github.com/M66B/FairEmail/blob/master/FAQ.md#user-content-get-support)
* agree to [the license and the copyright](https://github.com/M66B/FairEmail#user-content-license)

Thanks for your intention to contribute to the project!
