### PR TITLE
allow DMARC row validation for SPF IP without prefix

### DIFF
--- a/app/src/main/java/eu/faircode/email/ActivityDmarc.java
+++ b/app/src/main/java/eu/faircode/email/ActivityDmarc.java
@@ -274,7 +274,7 @@ public class ActivityDmarc extends ActivityBase {
                                                                 String[] net = ip.substring(4).split("/");
                                                                 if (net.length > 2)
                                                                     continue;
-                                                                Integer prefix = ip.startsWith("ip4:") ? 32 : 64;
+                                                                Integer prefix = ip.startsWith("ip4:") ? 32 : 128;
                                                                 if (net.length == 2)
                                                                     prefix = Helper.parseInt(net[1]);
                                                                 if (prefix == null)

--- a/app/src/main/java/eu/faircode/email/ActivityDmarc.java
+++ b/app/src/main/java/eu/faircode/email/ActivityDmarc.java
@@ -272,9 +272,11 @@ public class ActivityDmarc extends ActivityBase {
                                                             ip = ip.toLowerCase(Locale.ROOT);
                                                             if (ip.startsWith("ip4:") || ip.startsWith("ip6:")) {
                                                                 String[] net = ip.substring(4).split("/");
-                                                                if (net.length != 2)
+                                                                if (net.length > 2)
                                                                     continue;
-                                                                Integer prefix = Helper.parseInt(net[1]);
+                                                                Integer prefix = ip.startsWith("ip4:") ? 32 : 64;
+                                                                if (net.length == 2)
+                                                                    prefix = Helper.parseInt(net[1]);
                                                                 if (prefix == null)
                                                                     continue;
                                                                 if (ConnectionHelper.inSubnet(text, net[0], prefix)) {


### PR DESCRIPTION
The current DMARC-report activity flags all (valid) sender IPs as invalid if the provided SPF record defines an IP without prefix. However the SPF "ip4" and "ip6" mechanism definitions allow IPs without a prefix, see: https://www.rfc-editor.org/rfc/rfc7208#section-5.6

I confirm that I:
* read the [contributing section](https://github.com/M66B/FairEmail#user-content-contributing)
* agree to [the license and the copyright](https://github.com/M66B/FairEmail#user-content-license)
* was totally blown away by the nice way DMARC reports are shown in FairEmail :) 