### PR TITLE
disable ELF build-id for github flavor

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -205,6 +205,15 @@ android {
             dimension "all"
             manifestPlaceholders.largeHeap = false
             manifestPlaceholders.build_uuid = UUID.nameUUIDFromBytes(("github" + getVersionCode() + getRevision()).getBytes()).toString();
+            externalNativeBuild {
+                cmake {
+                    arguments "-DCMAKE_SHARED_LINKER_FLAGS=-Wl,--build-id=none" // -z,max-page-size=16384
+                    // https://gitlab.com/IzzyOnDroid/repo/-/wikis/Reproducible-Builds
+                    // The build ID is a 160-bit SHA1 string computed over the elf header bits and section contents in the file.
+                    // It is bundled in the elf file as an entry in the notes section.
+                    //   readelf -n ./app/build/intermediates/stripped_native_libs/xxxRelease/out/lib/armeabi-v7a/libfairemail.so
+                }
+            }
             buildConfigField "boolean", "TEST_RELEASE", "false"
             buildConfigField "boolean", "BETA_RELEASE", "true"
             buildConfigField "boolean", "PLAY_STORE_RELEASE", "false"


### PR DESCRIPTION
At IzzyOnDroid we support [Reproducible Builds](https://reproducible-builds.org/) (see: [Reproducible Builds, special client support and more in our repo](https://android.izzysoft.de/articles/named/iod-rbs-mirrors-clients?lang=en)).

Your app has been reproducible for quite a while. Unfortunately, `libfairemail.so` contains a build-id, which means the only way to create an identical build is to patch the cmake config to inject the same one found in the release APKs, which requires manual work to keep up to date. It would be a lot easier for us if you could disable the build-id for the github flavor (as is already done for the fdroid flavor) as well.

We'd appreciate if you could help making your build reproducible. We've prepared some [hints on Reproducible Builds](https://gitlab.com/IzzyOnDroid/repo/-/wikis/Reproducible-Builds).

Thank you!

cc @IzzySoft

---

I confirm I read the [contributing section](https://github.com/M66B/FairEmail#user-content-contributing), [get support section](https://github.com/M66B/FairEmail/blob/master/FAQ.md#user-content-get-support) and agree to [the license and the copyright](https://github.com/M66B/FairEmail#user-content-license).