### PR TITLE
Add long press link to show confirmation dialog in FAQ.md

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -5701,6 +5701,8 @@ If you disabled confirming links, you can enable this (temporarily) again in the
 
 Note that you might need to enable confirming links and reset questions to show the link confirmation dialog again.
 
+You can also long press a link to show the link confirmation dialog.
+
 Please see [this FAQ](#faq35) on why you should be careful when opening links.
 
 <br />


### PR DESCRIPTION
1.2160 - 2024-02-19 added long press link to show confirmation dialog, so it makes sense to mention it in the FAQ.

# Important

Please confirm that you:

* read the [contributing section](https://github.com/M66B/FairEmail#user-content-contributing)
* read the [get support section](https://github.com/M66B/FairEmail/blob/master/FAQ.md#user-content-get-support)
* agree to [the license and the copyright](https://github.com/M66B/FairEmail#user-content-license)

Thanks for your intention to contribute to the project!
